### PR TITLE
Chore: remove unneeded redirection to `/dev/stdout`

### DIFF
--- a/.github/scripts/override_mods.sh
+++ b/.github/scripts/override_mods.sh
@@ -89,7 +89,7 @@ mediafire_override () {
     PATH_MEDIAFIRE=$2
 
     echo "下載 $1"
-    wget "$(wget -qO - "$3" > /dev/stdout | grep 'id="downloadButton"' | grep -Po '(?<=href=")[^"]*')"
+    wget "$(wget -qO - "$3" | grep 'id="downloadButton"' | grep -Po '(?<=href=")[^"]*')"
 
     echo "取出 $1 翻譯檔"
     $JAVA_HOME_17_X64/bin/jar xf $4 $PATH_MEDIAFIRE/zh_tw.json
@@ -121,7 +121,7 @@ mediafire_tinker_override () {
     PATH_MEDIAFIRE_TINKER_BOOKS=$3
 
     echo "下載 $1"
-    wget "$(wget -qO - "$4" > /dev/stdout | grep 'id="downloadButton"' | grep -Po '(?<=href=")[^"]*')"
+    wget "$(wget -qO - "$4"  | grep 'id="downloadButton"' | grep -Po '(?<=href=")[^"]*')"
 
     echo "解壓縮 $1 Jar"
     $JAVA_HOME_17_X64/bin/jar xf $5

--- a/.github/scripts/override_mods.sh
+++ b/.github/scripts/override_mods.sh
@@ -121,7 +121,7 @@ mediafire_tinker_override () {
     PATH_MEDIAFIRE_TINKER_BOOKS=$3
 
     echo "下載 $1"
-    wget "$(wget -qO - "$4"  | grep 'id="downloadButton"' | grep -Po '(?<=href=")[^"]*')"
+    wget "$(wget -qO - "$4" | grep 'id="downloadButton"' | grep -Po '(?<=href=")[^"]*')"
 
     echo "解壓縮 $1 Jar"
     $JAVA_HOME_17_X64/bin/jar xf $5


### PR DESCRIPTION
`wget` output is already commited to `stdout` by `-O -`, therefore the redirection(`> /dev/stdout` can be removed