### PR TITLE
mods_localize(Chat Heads): 修正在地化用語

### DIFF
--- a/assets/chat_heads/lang/zh_tw.json
+++ b/assets/chat_heads/lang/zh_tw.json
@@ -1,5 +1,5 @@
 {
-  "text.autoconfig.chat_heads.title": "聊天室頭像",
+  "text.autoconfig.chat_heads.title": "聊天室頭貼",
   "text.autoconfig.chat_heads.option.offsetNonPlayerText": "非玩家的聊天訊息偏移值",
   "text.autoconfig.chat_heads.option.offsetNonPlayerText.@Tooltip": "當啟用時，所有訊息將會被對齊",
   "text.autoconfig.chat_heads.option.explanation": "「UUID」？「啟發式」？",


### PR DESCRIPTION
修正 chat_heads 模組中的 `頭像` 改為 `頭貼` 以符合繁體中文（台灣）的在地化用語