### PR TITLE
mods_feat(Better Mods Button): 新增更好的模組按鈕 v4.2.1

### DIFF
--- a/MultiVersions/Forge/main/bettermodsbutton/lang/en_us.json
+++ b/MultiVersions/Forge/main/bettermodsbutton/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+  "button.mods.count": "(%s Loaded)",
+  "button.mods.count.compact": "(%s)"
+}

--- a/MultiVersions/Forge/main/bettermodsbutton/lang/zh_tw.json
+++ b/MultiVersions/Forge/main/bettermodsbutton/lang/zh_tw.json
@@ -1,0 +1,4 @@
+{
+  "button.mods.count": "(已載入 %s 個)",
+  "button.mods.count.compact": "(%s)"
+}


### PR DESCRIPTION
維持半形標點符號的原因是，在遊戲中使用全形標點符號的視覺效果並不是很好。