### PR TITLE
mods_feat(Gilded Armor): 新增鑲金盔甲 v1.7.0

### DIFF
--- a/MultiVersions/Forge/main/gildedarmor/lang/en_us.json
+++ b/MultiVersions/Forge/main/gildedarmor/lang/en_us.json
@@ -1,0 +1,17 @@
+{
+  "item.gildedarmor.gilded_netherite_helmet": "Gilded Netherite Helmet",
+  "item.gildedarmor.gilded_netherite_chestplate": "Gilded Netherite Chestplate",
+  "item.gildedarmor.gilded_netherite_leggings": "Gilded Netherite Leggings",
+  "item.gildedarmor.gilded_netherite_boots": "Gilded Netherite Boots",
+  "item.gildedarmor.gilded_enderite_helmet": "Gilded Enderite Helmet",
+  "item.gildedarmor.gilded_enderite_chestplate": "Gilded Enderite Chestplate",
+  "item.gildedarmor.gilded_enderite_leggings": "Gilded Enderite Leggings",
+  "item.gildedarmor.gilded_enderite_boots": "Gilded Enderite Boots",
+
+  "item.gildedarmor.smithing_template.gilding_upgrade.applies_to": "Netherite (and Enderite) Armor",
+  "item.gildedarmor.smithing_template.gilding_upgrade.ingredients": "Gold Ingot",
+  "item.gildedarmor.smithing_template.gilding_upgrade.base_slot_description": "Put a piece of Netherite (or Enderite) armor here",
+  "item.gildedarmor.smithing_template.gilding_upgrade.additions_slot_description": "Put a Gold Ingot here",
+
+  "upgrade.gildedarmor.gilding_upgrade": "Gilding Upgrade"
+}

--- a/MultiVersions/Forge/main/gildedarmor/lang/zh_tw.json
+++ b/MultiVersions/Forge/main/gildedarmor/lang/zh_tw.json
@@ -3,14 +3,14 @@
   "item.gildedarmor.gilded_netherite_chestplate": "鑲金獄髓胸甲",
   "item.gildedarmor.gilded_netherite_leggings": "鑲金獄髓護腿",
   "item.gildedarmor.gilded_netherite_boots": "鑲金獄髓靴子",
-  "item.gildedarmor.gilded_enderite_helmet": "鑲金終界髓頭盔",
-  "item.gildedarmor.gilded_enderite_chestplate": "鑲金終界髓胸甲",
-  "item.gildedarmor.gilded_enderite_leggings": "鑲金終界髓護腿",
-  "item.gildedarmor.gilded_enderite_boots": "鑲金終界髓靴子",
+  "item.gildedarmor.gilded_enderite_helmet": "鑲金終髓頭盔",
+  "item.gildedarmor.gilded_enderite_chestplate": "鑲金終髓胸甲",
+  "item.gildedarmor.gilded_enderite_leggings": "鑲金終髓護腿",
+  "item.gildedarmor.gilded_enderite_boots": "鑲金終髓靴子",
 
-  "item.gildedarmor.smithing_template.gilding_upgrade.applies_to": "獄髓（及終界髓）裝備",
+  "item.gildedarmor.smithing_template.gilding_upgrade.applies_to": "獄髓（及終髓）裝備",
   "item.gildedarmor.smithing_template.gilding_upgrade.ingredients": "金錠",
-  "item.gildedarmor.smithing_template.gilding_upgrade.base_slot_description": "放置獄髓（或終界髓）盔甲",
+  "item.gildedarmor.smithing_template.gilding_upgrade.base_slot_description": "放置獄髓（或終髓）盔甲",
   "item.gildedarmor.smithing_template.gilding_upgrade.additions_slot_description": "放置金錠",
 
   "upgrade.gildedarmor.gilding_upgrade": "鑲金升級"

--- a/MultiVersions/Forge/main/gildedarmor/lang/zh_tw.json
+++ b/MultiVersions/Forge/main/gildedarmor/lang/zh_tw.json
@@ -8,9 +8,9 @@
   "item.gildedarmor.gilded_enderite_leggings": "鑲金終界髓護腿",
   "item.gildedarmor.gilded_enderite_boots": "鑲金終界髓靴子",
 
-  "item.gildedarmor.smithing_template.gilding_upgrade.applies_to": "獄髓（及終界髓）盔甲",
+  "item.gildedarmor.smithing_template.gilding_upgrade.applies_to": "獄髓（及終界髓）裝備",
   "item.gildedarmor.smithing_template.gilding_upgrade.ingredients": "金錠",
-  "item.gildedarmor.smithing_template.gilding_upgrade.base_slot_description": "放置獄髓（或終界髓）裝備",
+  "item.gildedarmor.smithing_template.gilding_upgrade.base_slot_description": "放置獄髓（或終界髓）盔甲",
   "item.gildedarmor.smithing_template.gilding_upgrade.additions_slot_description": "放置金錠",
 
   "upgrade.gildedarmor.gilding_upgrade": "鑲金升級"

--- a/MultiVersions/Forge/main/gildedarmor/lang/zh_tw.json
+++ b/MultiVersions/Forge/main/gildedarmor/lang/zh_tw.json
@@ -1,0 +1,17 @@
+{
+  "item.gildedarmor.gilded_netherite_helmet": "鑲金獄髓頭盔",
+  "item.gildedarmor.gilded_netherite_chestplate": "鑲金獄髓胸甲",
+  "item.gildedarmor.gilded_netherite_leggings": "鑲金獄髓護腿",
+  "item.gildedarmor.gilded_netherite_boots": "鑲金獄髓靴子",
+  "item.gildedarmor.gilded_enderite_helmet": "鑲金終界髓頭盔",
+  "item.gildedarmor.gilded_enderite_chestplate": "鑲金終界髓胸甲",
+  "item.gildedarmor.gilded_enderite_leggings": "鑲金終界髓護腿",
+  "item.gildedarmor.gilded_enderite_boots": "鑲金終界髓靴子",
+
+  "item.gildedarmor.smithing_template.gilding_upgrade.applies_to": "獄髓（及終界髓）盔甲",
+  "item.gildedarmor.smithing_template.gilding_upgrade.ingredients": "金錠",
+  "item.gildedarmor.smithing_template.gilding_upgrade.base_slot_description": "放置獄髓（或終界髓）裝備",
+  "item.gildedarmor.smithing_template.gilding_upgrade.additions_slot_description": "放置金錠",
+
+  "upgrade.gildedarmor.gilding_upgrade": "鑲金升級"
+}


### PR DESCRIPTION
### **沿用：**
-  **_"item.gildedarmor.smithing_template.gilding_upgrade.applies_to": "獄髓（及終界髓）裝備",_**
沿用原版 item.minecraft.smithing_template.netherite_upgrade.applies_to": "鑽石裝備"

-  **_"item.gildedarmor.smithing_template.gilding_upgrade.base_slot_description": "放置獄髓（或終界髓）盔甲",_**
沿用原版 item.minecraft.smithing_template.netherite_upgrade.base_slot_description: "放置鑽石盔甲、武器或工具"