### PR TITLE
mods_feat(Serene Seasons): 新增靜謐四季 v9.0.0.43

### DIFF
--- a/MultiVersions/Forge/main/sereneseasons/lang/en_us.json
+++ b/MultiVersions/Forge/main/sereneseasons/lang/en_us.json
@@ -1,0 +1,34 @@
+{
+  "commands.sereneseasons.usage": "/season <get/set> [args]",
+  "commands.sereneseasons.getseason.success": "Current season is %s, day %s/%s, tick %s/%s",
+  "commands.sereneseasons.setseason.success": "Set season to %s",
+  "commands.sereneseasons.setseason.fail": "Invalid season %s",
+  "commands.sereneseasons.setseason.disabled": "Seasons are currently disabled!",
+
+  "itemGroup.tabSereneSeasons": "Serene Seasons",
+
+  "block.sereneseasons.season_sensor": "Season Sensor",
+  
+  "item.sereneseasons.ss_icon": "SS Icon",
+  "item.sereneseasons.calendar": "Calendar",
+
+  "desc.sereneseasons.fertile_seasons": "Fertile Seasons",
+  "desc.sereneseasons.year_round": "Year-Round",
+  "desc.sereneseasons.day_counter": "Day %s/%s",
+  "desc.sereneseasons.spring": "Spring",
+  "desc.sereneseasons.early_spring": "Early Spring",
+  "desc.sereneseasons.mid_spring": "Mid Spring",
+  "desc.sereneseasons.late_spring": "Late Spring",
+  "desc.sereneseasons.summer": "Summer",
+  "desc.sereneseasons.early_summer": "Early Summer",
+  "desc.sereneseasons.mid_summer": "Mid Summer",
+  "desc.sereneseasons.late_summer": "Late Summer",
+  "desc.sereneseasons.autumn": "Autumn",
+  "desc.sereneseasons.early_autumn": "Early Autumn",
+  "desc.sereneseasons.mid_autumn": "Mid Autumn",
+  "desc.sereneseasons.late_autumn": "Late Autumn",
+  "desc.sereneseasons.winter": "Winter",
+  "desc.sereneseasons.early_winter": "Early Winter",
+  "desc.sereneseasons.mid_winter": "Mid Winter",
+  "desc.sereneseasons.late_winter": "Late Winter"
+}

--- a/MultiVersions/Forge/main/sereneseasons/lang/zh_tw.json
+++ b/MultiVersions/Forge/main/sereneseasons/lang/zh_tw.json
@@ -1,0 +1,34 @@
+{
+  "commands.sereneseasons.usage": "/season <get/set> [args]",
+  "commands.sereneseasons.getseason.success": "現在是%s的第 %s/%s 天，第 %s/%s 刻",
+  "commands.sereneseasons.setseason.success": "設定季節為 %s",
+  "commands.sereneseasons.setseason.fail": "季節%s無效",
+  "commands.sereneseasons.setseason.disabled": "已停用季節更迭！",
+
+  "itemGroup.tabSereneSeasons": "靜謐四季",
+
+  "block.sereneseasons.season_sensor": "季節感測器",
+  
+  "item.sereneseasons.ss_icon": "靜謐四季圖示",
+  "item.sereneseasons.calendar": "日曆",
+
+  "desc.sereneseasons.fertile_seasons": "生長季",
+  "desc.sereneseasons.year_round": "一年四季",
+  "desc.sereneseasons.day_counter": "第 %s/%s 天",
+  "desc.sereneseasons.spring": "春季",
+  "desc.sereneseasons.early_spring": "初春",
+  "desc.sereneseasons.mid_spring": "仲春",
+  "desc.sereneseasons.late_spring": "晚春",
+  "desc.sereneseasons.summer": "夏季",
+  "desc.sereneseasons.early_summer": "初夏",
+  "desc.sereneseasons.mid_summer": "仲夏",
+  "desc.sereneseasons.late_summer": "晚夏",
+  "desc.sereneseasons.autumn": "秋季",
+  "desc.sereneseasons.early_autumn": "初秋",
+  "desc.sereneseasons.mid_autumn": "仲秋",
+  "desc.sereneseasons.late_autumn": "晚秋",
+  "desc.sereneseasons.winter": "冬季",
+  "desc.sereneseasons.early_winter": "初冬",
+  "desc.sereneseasons.mid_winter": "仲冬",
+  "desc.sereneseasons.late_winter": "晚冬"
+}


### PR DESCRIPTION
### **其他：**

- **_"block.sereneseasons.season_sensor": "季節感測器",_**
原文 Sensor 在原版是指振測器，但功能和日光感測器類似，就翻成感測器了

生長季和其他幾個翻譯沿用內建繁中，模組譯名是簡中翻譯