### PR TITLE
mods_feat(ClickThrough): 新增點擊穿透 v0.4.1

### DIFF
--- a/MultiVersions/Fabric/main/clickthrough/lang/en_us.json
+++ b/MultiVersions/Fabric/main/clickthrough/lang/en_us.json
@@ -1,0 +1,35 @@
+{
+    "clickthrough.config.sneaktodye": "Sneak to dye signs",
+    "clickthrough.config.tt.sneaktodye": "ON: Click clicks through, sneak dyes signs\nOFF: Click dyes signs, sneak does not dye",
+    
+    "clickthrough.config.ignore.1": "Ignore signs if row 1 matches: ",
+    "clickthrough.config.ignore.2": "Ignore signs if row 2 matches: ",
+    "clickthrough.config.ignore.3": "Ignore signs if row 3 matches: ",
+    "clickthrough.config.ignore.4": "Ignore signs if row 4 matches: ",
+    "clickthrough.config.onlycontainers": "Only click through to containers",
+    "clickthrough.config.switchonattack": "Reroute left button as well",
+
+    "clickthrough.config.tt.ignore.1": "Do not click through those signs for the benefit of chest shops",
+    "clickthrough.config.tt.ignore.2": "Do not click through those signs for the benefit of chest shops",
+    "clickthrough.config.tt.ignore.3": "Do not click through those signs for the benefit of chest shops",
+    "clickthrough.config.tt.ignore.4": "Do not click through those signs for the benefit of chest shops",
+    "clickthrough.config.tt.onlycontainers": "Click through to chests, barrels etc., but not crafting tables, composters and similar",
+    "clickthrough.config.tt.switchonattack": "Also redirect left button clicks to what's behind the sign",
+
+    "key.categories.clickthrough": "ClickThrough",
+    "key.clickthrough.toggle": "Turn ClickThrough on/off",
+    "clickthrough.msg.active": "ClickThrough active",
+    "clickthrough.msg.inactive": "ClickThrough inactive",
+
+    "clickthrough.config.switchonattack.never": "Never",
+    "clickthrough.config.switchonattack.first": "First click",
+    "clickthrough.config.switchonattack.always": "Always",
+
+  "text.autoconfig.clickthrough.title": "Clickthrough Control",
+  "text.autoconfig.clickthrough.category.clickthrough": "Clickthrough",
+  "text.autoconfig.clickthrough.option.clickthroughToggleOn": "Toggle if clickthrough is enabled",
+  "text.autoconfig.clickthrough.option.clickthroughWallSigns": "Toggle if clickthrough Wall Signs",
+  "text.autoconfig.clickthrough.option.clickthroughItemFrames": "Toggle if clickthrough Item Frames",
+  "text.autoconfig.clickthrough.option.clickthroughGlowItemFrames": "Toggle if clickthrough Glow Item Frames",
+  "text.autoconfig.clickthrough.option.clickthroughWallBanners": "Toggle if clickthrough Wall Banners"
+}

--- a/MultiVersions/Fabric/main/clickthrough/lang/zh_tw.json
+++ b/MultiVersions/Fabric/main/clickthrough/lang/zh_tw.json
@@ -1,0 +1,35 @@
+{
+    "clickthrough.config.sneaktodye": "潛行來染色告示牌",
+    "clickthrough.config.tt.sneaktodye": "啟用：點擊穿透告示牌，潛行染色告示牌\n關閉：點擊染色告示牌，潛行不會染色告示牌",
+    
+    "clickthrough.config.ignore.1": "當告示牌第一行符合時忽略：",
+    "clickthrough.config.ignore.2": "當告示牌第二行符合時忽略：",
+    "clickthrough.config.ignore.3": "當告示牌第三行符合時忽略：",
+    "clickthrough.config.ignore.4": "當告示牌第四行符合時忽略：",
+    "clickthrough.config.onlycontainers": "僅點擊穿透到容器",
+    "clickthrough.config.switchonattack": "也重新定向左鍵按鈕",
+
+    "clickthrough.config.tt.ignore.1": "對於儲物箱商店，不要點擊穿透那些告示牌會比較好",
+    "clickthrough.config.tt.ignore.2": "對於儲物箱商店，不要點擊穿透那些告示牌會比較好",
+    "clickthrough.config.tt.ignore.3": "對於儲物箱商店，不要點擊穿透那些告示牌會比較好",
+    "clickthrough.config.tt.ignore.4": "對於儲物箱商店，不要點擊穿透那些告示牌會比較好",
+    "clickthrough.config.tt.onlycontainers": "點擊穿透儲物箱、木桶等等。但不包含類似工作台、堆肥桶等。",
+    "clickthrough.config.tt.switchonattack": "同樣也會重新定向左鍵到告示牌後方的按鈕",
+
+    "key.categories.clickthrough": "點擊穿透",
+    "key.clickthrough.toggle": "開關點擊穿透",
+    "clickthrough.msg.active": "點擊穿透已啟用",
+    "clickthrough.msg.inactive": "點擊穿透未啟用",
+
+    "clickthrough.config.switchonattack.never": "永不",
+    "clickthrough.config.switchonattack.first": "第一次點擊",
+    "clickthrough.config.switchonattack.always": "總是",
+
+  "text.autoconfig.clickthrough.title": "點擊穿透控制",
+  "text.autoconfig.clickthrough.category.clickthrough": "點擊穿透",
+  "text.autoconfig.clickthrough.option.clickthroughToggleOn": "開關點擊穿透",
+  "text.autoconfig.clickthrough.option.clickthroughWallSigns": "開關點擊穿透牆上的告示牌",
+  "text.autoconfig.clickthrough.option.clickthroughItemFrames": "開關點擊穿透物品展示框",
+  "text.autoconfig.clickthrough.option.clickthroughGlowItemFrames": "開關點擊穿透螢光物品展示框",
+  "text.autoconfig.clickthrough.option.clickthroughWallBanners": "開關點擊穿透牆上的旗幟"
+}


### PR DESCRIPTION
會看到有兩種縮排的原因是
當我翻譯好去察看的時候發現原始程式碼儲存庫
並沒有真正儲存到目前所使用的語言檔案

所以只有最底下那些才會在遊戲中看見（text.autoconfig 開頭）